### PR TITLE
disable the GSCLK when no LEDs are on

### DIFF
--- a/TLC5955.cpp
+++ b/TLC5955.cpp
@@ -212,15 +212,19 @@ void TLC5955::setControlModeBit(bool is_control_mode)
 
 void TLC5955::updateLeds()
 {
+  // Get number of counts for current pattern
+  uint32_t power_output_counts = 0;
+  for (int16_t chip = (int8_t)_tlc_count - 1; chip >= 0; chip--)
+    for (int8_t led_channel_index = (int8_t)LEDS_PER_CHIP - 1; led_channel_index >= 0; led_channel_index--)
+      for (int8_t color_channel_index = (int8_t)COLOR_CHANNEL_COUNT - 1; color_channel_index >= 0; color_channel_index--)
+        power_output_counts += _grayscale_data[chip][led_channel_index][color_channel_index];
+  if (power_output_counts == 0) {
+    analogWrite(_gsclk, 0);
+  } else {
+    setGsclkFreq(gsclk_frequency);
+  }
   if (enforce_max_current)
   {
-    // Get number of counts for current pattern
-    uint32_t power_output_counts = 0;
-    for (int16_t chip = (int8_t)_tlc_count - 1; chip >= 0; chip--)
-      for (int8_t led_channel_index = (int8_t)LEDS_PER_CHIP - 1; led_channel_index >= 0; led_channel_index--)
-        for (int8_t color_channel_index = (int8_t)COLOR_CHANNEL_COUNT - 1; color_channel_index >= 0; color_channel_index--)
-          power_output_counts += _grayscale_data[chip][led_channel_index][color_channel_index];
-
     double power_output_amps = ((double)power_output_counts / (double)UINT16_MAX) * LED_CURRENT_AMPS;
     if (power_output_amps > max_current_amps)
     {

--- a/TLC5955.cpp
+++ b/TLC5955.cpp
@@ -221,7 +221,7 @@ void TLC5955::updateLeds()
   if (power_output_counts == 0) {
     analogWrite(_gsclk, 0);
   } else {
-    setGsclkFreq(gsclk_frequency);
+    analogWrite(_gsclk, 1);
   }
   if (enforce_max_current)
   {


### PR DESCRIPTION
This has a rather minor effect on the TLC5955, but I think it should still help.

Doesn't seem to modify things too much in terms of performance

![image](https://user-images.githubusercontent.com/90008/86543725-17374b80-bed6-11ea-8de0-8122d2dd2f64.png)

Shoudl save about 3mA of current per driver. Not entirely negligeable.