### PR TITLE
Fix management of SPI settings

### DIFF
--- a/TLC5955.cpp
+++ b/TLC5955.cpp
@@ -39,6 +39,8 @@ void TLC5955::init(uint8_t gslat, uint8_t spi_mosi, uint8_t spi_clk, uint8_t gsc
   _spi_mosi = spi_mosi;
   _gsclk = gsclk;
 
+  mSettings = SPISettings(spi_baud_rate, MSBFIRST, SPI_MODE0);
+
   // Initialize SPI library
   SPI.setMOSI(_spi_mosi);
   SPI.begin();
@@ -59,6 +61,8 @@ void TLC5955::setSpiBaudRate(uint32_t new_baud_rate)
 {
   // Store old baud rate
   spi_baud_rate = new_baud_rate;
+
+  mSettings = SPISettings(spi_baud_rate, MSBFIRST, SPI_MODE0);
 }
 
 uint32_t TLC5955::getSpiBaudRate()
@@ -158,7 +162,7 @@ void TLC5955::setAllLedRgb(uint16_t red, uint16_t green, uint16_t blue)
 void TLC5955::flushBuffer()
 {
   setControlModeBit(CONTROL_MODE_OFF);
-  SPI.beginTransaction(SPISettings(spi_baud_rate, MSBFIRST, SPI_MODE0));
+  SPI.beginTransaction(mSettings);
   for (int16_t fCount = 0; fCount < _tlc_count * TOTAL_REGISTER_SIZE / 8; fCount++)
     SPI.transfer(0);
   SPI.endTransaction();
@@ -241,7 +245,7 @@ void TLC5955::updateLeds()
   for (int16_t chip = (int8_t)_tlc_count - 1; chip >= 0; chip--)
   {
     setControlModeBit(CONTROL_MODE_OFF);
-    SPI.beginTransaction(SPISettings(spi_baud_rate, MSBFIRST, SPI_MODE0));
+    SPI.beginTransaction(mSettings);
     uint8_t color_channel_ordered;
     for (int8_t led_channel_index = (int8_t)LEDS_PER_CHIP - 1; led_channel_index >= 0; led_channel_index--)
     {
@@ -473,7 +477,7 @@ void TLC5955::setBuffer(uint8_t bit)
 {
   bitWrite(_buffer, _buffer_count, bit);
   _buffer_count--;
-  SPI.beginTransaction(SPISettings(spi_baud_rate, MSBFIRST, SPI_MODE0));
+  SPI.beginTransaction(mSettings);
   if (_buffer_count == -1)
   {
     if (debug >= 2)

--- a/TLC5955.h
+++ b/TLC5955.h
@@ -34,6 +34,7 @@
 #define TLC5955_H
 
 #include <stdint.h>
+#include <SPI.h>
 
 /* Bit Quantities (Change to match other TLC driver chips) */
 #define GS_BITS 16
@@ -141,6 +142,8 @@ private:
   int8_t _buffer_count = 7;
   uint32_t spi_baud_rate = 1000000;
   uint32_t gsclk_frequency = 2500000;
+
+  SPISettings mSettings;
 };
 
 #endif


### PR DESCRIPTION
This addresses some problems with creating the SPI settings, which were leading to serial timeout errors when loading the files onto our LED boards.

In a previous version, beginTransaction() was always called with the class's mSettings object. However, mSettings was never properly created as a local object, so a default SPISettings object was created every time beginTransaction was called. In that version, we did not actually have any control over the SPI settings, including the baud rate. In the current version prior to this pull request, the problem was addressed by explicitly creating a new SPISettings object whenever beginTransaction was called. This object was created with the correct baud rate. However, creating the SPISettings object with non-default attributes takes longer than creating the default object, which led to serial timeout errors.

This request fixes that error by correctly creating the SPISettings object mSettings only when the class is first initialized, and whenever the baud rate is changed. This prevents the timeout errors while ensuring we have control over the SPI settings being used. 


